### PR TITLE
prevent map from being opened inside an iframe

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -1338,7 +1338,7 @@ var aircraftHash = "#aircraft";
 var mapHash = "#map";
 
 function onLoad() {
-    if (true) {
+    if (!checkIframe()) {
         // For back button handling
         previousHash.push(mainHash);
         previousHash.push(mapHash);


### PR DESCRIPTION
add a check onload to see if the page is opened on an iframe, if it is - redirect it to press.html.