### PR TITLE
fix: prevent route from overriding existing points

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -551,10 +551,12 @@ function updateLocationsMap(aircrafts) {
 
 function updateLocations(route) {
     route.points.forEach(function (point) {
-        locations[point.pointId] = point;
-        locations[point.pointId].aircrafts = [];
-        locations[point.pointId].hideAircrafts = point.hideAircrafts;
-        locations[point.pointId].color = route.color;
+        if(!locations[point.pointId]){
+            locations[point.pointId] = point;
+            locations[point.pointId].aircrafts = [];
+            locations[point.pointId].hideAircrafts = point.hideAircrafts;
+            locations[point.pointId].color = route.color;
+        }
     }, this);
 }
 


### PR DESCRIPTION
יש לנו בעיה של חוסר עקביות בנתונים - אותן נקודות מופיעות עם מידע שונה בpoints.json ובroutes.json.
הפתרון שאני מציע - למנוע מroutes לדרוס מידע שנמצא בpoints (בהנחה ויש מידע בpoints).

תודה